### PR TITLE
Ignorer la casse dans le valeurs de `eduPersonAffiliation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- match eduPersonAffiliation case-insensitively
+
 ## [1.0.13] - 2026-03-26 
 - switch to stateless OIDC and remove Redis
 

--- a/src/satosa/plugins/microservices/attribute_authorization.yaml
+++ b/src/satosa/plugins/microservices/attribute_authorization.yaml
@@ -13,8 +13,8 @@ config:
           # later in the PrimaryIdentifier processor.
           - ".+"
         eduPersonAffiliation:
-          - "^faculty$"
-          - "^staff$"
-          - "^employee$"
-          - "^researcher$"
-          - "^teacher$"
+          - "(?i)^FACULTY$"
+          - "(?i)^STAFF$"
+          - "(?i)^EMPLOYEE$"
+          - "(?i)^RESEARCHER$"
+          - "(?i)^TEACHER$"

--- a/start-kind.sh
+++ b/start-kind.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -o errexit
+#!/usr/bin/env bash
+set -euo pipefail
 
 CURRENT_DIR=$(pwd)
 


### PR DESCRIPTION
## Problème

Certains utilisateurs rencontrent des erreurs de connexion parce que leur IdP renvoie des valeurs de `eduPersonAffiliation` qui sont en majuscules (ex. `EMPLOYEE`).

Or, la recommandation SupAnn indique que la casse doit être ignorée lors de la comparaison de cet attribut, voir https://services.renater.fr/documentation/supann/courant/recommandations/attributs/edupersonaffiliation .

## Proposition de solution

On ajoute un flag `(?i)` qui permet d'ignorer la casse, au début des expressions régulières utilisées pour valider les valeurs de `eduPersonAffiliation`.