### PR TITLE
🚸Show custom error message for failed affiliation checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- return detailed OIDC error on eduPersonAffiliation error
+
 ## [1.0.14] - 2026-05-20
 - match eduPersonAffiliation case-insensitively
 

--- a/src/satosa/oidc2fer/authorization/__init__.py
+++ b/src/satosa/oidc2fer/authorization/__init__.py
@@ -1,0 +1,1 @@
+from .affiliation_checker import AffiliationChecker

--- a/src/satosa/oidc2fer/authorization/affiliation_checker.py
+++ b/src/satosa/oidc2fer/authorization/affiliation_checker.py
@@ -1,0 +1,29 @@
+from satosa.exception import SATOSAAuthenticationError
+from satosa.micro_services.base import ResponseMicroService
+
+
+class AffiliationCheckError(SATOSAAuthenticationError):
+    def __init__(self, state, message):
+        super().__init__(state, message)
+        # Override SATOSAAuthenticationError's _message property to keep the custom message
+        self._message = message + " Error id [{error_id}]"
+
+
+class AffiliationChecker(ResponseMicroService):
+    def __init__(self, config, *args, **kwargs):
+        self.attribute_name = config.get("attribute_name", "eduPersonAffiliation")
+        self.allowed_values = set(config.get("allowed_values", []))
+        super().__init__(*args, **kwargs)
+
+    def process(self, context, data):
+        if self.attribute_name not in data.attributes:
+            raise AffiliationCheckError(
+                context.state, f"L'attribut {self.attribute_name} est manquant"
+            )
+        values = data.attributes[self.attribute_name]
+        if not any(v.lower() in self.allowed_values for v in values):
+            raise AffiliationCheckError(
+                context.state,
+                f"Aucune des valeurs pour {self.attribute_name} n'est autorisée: {values}",
+            )
+        return super().process(context, data)

--- a/src/satosa/plugins/microservices/affiliation_checker.yaml
+++ b/src/satosa/plugins/microservices/affiliation_checker.yaml
@@ -1,0 +1,10 @@
+module: oidc2fer.authorization.affiliation_checker.AffiliationChecker
+name: AffiliationChecker
+config:
+  attribute_name: eduPersonAffiliation
+  allowed_values:
+    - "faculty"
+    - "staff"
+    - "employee"
+    - "researcher"
+    - "teacher"

--- a/src/satosa/plugins/microservices/attribute_authorization.yaml
+++ b/src/satosa/plugins/microservices/attribute_authorization.yaml
@@ -12,9 +12,3 @@ config:
           # We require it to be non-empty here, to avoid an unhandled error
           # later in the PrimaryIdentifier processor.
           - ".+"
-        eduPersonAffiliation:
-          - "(?i)^FACULTY$"
-          - "(?i)^STAFF$"
-          - "(?i)^EMPLOYEE$"
-          - "(?i)^RESEARCHER$"
-          - "(?i)^TEACHER$"

--- a/src/satosa/proxy_conf.yaml
+++ b/src/satosa/proxy_conf.yaml
@@ -14,6 +14,7 @@ FRONTEND_MODULES:
 MICRO_SERVICES:
   - plugins/microservices/filter_attributes.yaml
   - plugins/microservices/attribute_authorization.yaml
+  - plugins/microservices/affiliation_checker.yaml
   - plugins/microservices/primary_identifier.yaml
   - plugins/microservices/static_attributes.yaml
   - plugins/microservices/attribute_processor.yaml

--- a/src/satosa/tests/oidc2fer/authorization/test_affiliation_checker.py
+++ b/src/satosa/tests/oidc2fer/authorization/test_affiliation_checker.py
@@ -1,0 +1,66 @@
+import pytest
+from satosa.context import Context
+from satosa.exception import SATOSAAuthenticationError
+from satosa.internal import AuthenticationInformation, InternalData
+
+from oidc2fer.authorization import AffiliationChecker
+
+
+class TestAffiliationChecker:
+    def create_affiliation_checker(self):
+        affiliation_checker = AffiliationChecker(
+            config={
+                "attribute_name": "eduPersonAffiliation",
+                "allowed_values": ["employee"],
+            },
+            name="test_affiliation_checker",
+            base_url="https://satosa.example.com",
+        )
+        affiliation_checker.next = lambda ctx, data: data
+        return affiliation_checker
+
+    def test_allows_expected_value(self):
+        authz_service = self.create_affiliation_checker()
+        resp = InternalData(auth_info=AuthenticationInformation())
+        resp.attributes = {
+            "eduPersonAffiliation": ["member", "employee"],
+        }
+        ctx = Context()
+        ctx.state = {}
+        authz_service.process(ctx, resp)
+
+    def test_case_insensitive_match(self):
+        authz_service = self.create_affiliation_checker()
+        resp = InternalData(auth_info=AuthenticationInformation())
+        resp.attributes = {
+            "eduPersonAffiliation": ["EmpLoyEe"],
+        }
+        ctx = Context()
+        ctx.state = {}
+        authz_service.process(ctx, resp)
+
+    def test_fail_when_attribute_missing(self):
+        authz_service = self.create_affiliation_checker()
+        resp = InternalData(auth_info=AuthenticationInformation())
+        resp.attributes = {}
+        with pytest.raises(
+            SATOSAAuthenticationError,
+            match="L'attribut eduPersonAffiliation est manquant",
+        ):
+            ctx = Context()
+            ctx.state = {}
+            authz_service.process(ctx, resp)
+
+    def test_fail_when_no_allowed_values(self):
+        authz_service = self.create_affiliation_checker()
+        resp = InternalData(auth_info=AuthenticationInformation())
+        resp.attributes = {
+            "eduPersonAffiliation": ["student"],
+        }
+        with pytest.raises(
+            SATOSAAuthenticationError,
+            match=r"Aucune des valeurs pour eduPersonAffiliation n'est autorisée: \['student'\]",
+        ):
+            ctx = Context()
+            ctx.state = {}
+            authz_service.process(ctx, resp)

--- a/src/satosa/tests/test_e2e.py
+++ b/src/satosa/tests/test_e2e.py
@@ -114,7 +114,14 @@ def test_oidc_to_renater_student_not_allowed(page: Page):
     renater_wayf(page)
     renater_test_idp(page, login="etudiant1")
 
-    expect(page.locator("pre")).to_contain_text('"error":"access_denied"')
+    text = page.inner_text("pre")
+    result = json.loads(text)
+    error_response = result.get("error_response")
+    assert error_response["error"] == "access_denied"
+    assert (
+        "Aucune des valeurs pour eduPersonAffiliation n'est autorisée: ['student', 'member']"
+        in error_response["error_description"]
+    )
 
 
 def pro_connect_login(page: Page, email):
@@ -169,6 +176,9 @@ def test_pro_connect_to_renater_student_not_allowed(page: Page):
     renater_test_idp(page, login="etudiant1")
 
     expect(page.locator("body")).to_contain_text("access_denied")
+    expect(page.locator("body")).to_contain_text(
+        "Aucune des valeurs pour eduPersonAffiliation n'est autorisée: ['student', 'member']"
+    )
 
 
 @pytest.mark.skipif(

--- a/src/satosa/tests/test_e2e.py
+++ b/src/satosa/tests/test_e2e.py
@@ -118,7 +118,7 @@ def test_oidc_to_renater_student_not_allowed(page: Page):
 
 
 def pro_connect_login(page: Page, email):
-    page.goto("https://fsa1v2.integ01.dev-agentconnect.fr/")
+    page.goto("https://test.proconnect.gouv.fr/")
     page.get_by_role("button", name="S’identifier avec ProConnect").click()
     page.get_by_label("Email professionnel").fill(email)
     page.get_by_test_id("interaction-connection-button").click()
@@ -136,7 +136,7 @@ def pro_connect_to_renater(
     renater_test_idp(page, login=login)
 
     expect(page.locator("body")).to_contain_text(expected_email)
-    text = page.inner_text("#userinfo")
+    text = page.inner_text("code")
     result = json.loads(text)
     assert {
         "uid": f"{login}@test-renater.fr",


### PR DESCRIPTION
## Problem

When a user's access is rejected because their `eduPersonAffiliation` attribute does not contain one of the required values, a generic "access denied" error message is generated, which is not helpful to let users contact their IdP admin to get their account fixed.

## Proposed solution

Replace the generic `attribute_authorization` plugin with custom code that raises a custom OIDC error containing more information. The error type had to be customized to override the default hiding of the error message.